### PR TITLE
Fix compatibility typo in OpenAI test docstring

### DIFF
--- a/tests/core/embedding_models/test_openai.py
+++ b/tests/core/embedding_models/test_openai.py
@@ -1,4 +1,4 @@
-"""Tests for OpenAI (and API compability) embedding models."""
+"""Tests for OpenAI (and API compatibility) embedding models."""
 
 import os
 import time


### PR DESCRIPTION
## Summary
- fix typo in OpenAI embedding model test docstring

## Testing
- `pytest tests/core/embedding_models/test_openai.py -q` *(fails: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_689315f2a65483269af9ad0f4018a386