### PR TITLE
Use preconfigured converter in PDF parser

### DIFF
--- a/src/stakan/core/parsers/pdf.py
+++ b/src/stakan/core/parsers/pdf.py
@@ -33,9 +33,7 @@ class PDFParser:
         table-structure analysis enabled. The extracted content is
         returned as a Markdown string.
         """
-        converter = DocumentConverter()
-
-        result = converter.convert(
+        result = self._doc_converter.convert(
             source=DocumentStream(name="", stream=BytesIO(document)),
         )
 


### PR DESCRIPTION
## Summary
- streamline PDFParser.parse to use the configured DocumentConverter

## Testing
- `ruff check src/stakan/core/parsers/pdf.py`
- `PYTHONPATH=src pytest` *(fails: No module named 'requests'; No module named 'docling')*

------
https://chatgpt.com/codex/tasks/task_e_68931945dc7c8326a57be55e37b5cdc9