### PR TITLE
Clarify PDF parser output

### DIFF
--- a/src/stakan/core/parsers/pdf.py
+++ b/src/stakan/core/parsers/pdf.py
@@ -27,7 +27,12 @@ class PDFParser:
         )
 
     def parse(self, document: bytes) -> str:
-        """Parse document bytes into `Document`."""
+        """Convert PDF bytes to Markdown text.
+
+        The PDF content is processed via Docling with OCR disabled and
+        table-structure analysis enabled. The extracted content is
+        returned as a Markdown string.
+        """
         converter = DocumentConverter()
 
         result = converter.convert(


### PR DESCRIPTION
## Summary
- clarify `PDFParser.parse` docstring to note Markdown output and Docling usage

## Testing
- `pytest` *(fails: Connection error; 2 failed, 10 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6893194671b883269ace10d6d9e7c6c6