### PR TITLE
Add Pydantic-based test configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "docling>=2.36.1",
     "openai>=1.86.0",
     "pydantic>=2.11.7",
+    "pydantic-settings>=2.3.0",
     "qdrant-client>=1.14.2",
 ]
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,4 @@
 """Tests for STAKAN lib, API and CLI."""
+
+# Expose shared test fixtures
+pytest_plugins = ["tests.config"]

--- a/tests/config/__init__.py
+++ b/tests/config/__init__.py
@@ -1,0 +1,25 @@
+"""Test configuration utilities."""
+
+import pytest
+from pydantic import HttpUrl
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Configuration for tests."""
+
+    model_name: str = "nomic-embed-text"
+    use_ollama: bool = False
+    ollama_url: HttpUrl = "http://localhost:11434/v1"
+    api_key: str = "ollama"
+
+    model_config = SettingsConfigDict(env_prefix="TEST_")
+
+
+@pytest.fixture(scope="session")
+def settings() -> Settings:
+    """Provide settings for tests."""
+    return Settings()
+
+
+__all__ = ["Settings", "settings"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'darwin'",
@@ -1996,6 +1996,7 @@ dependencies = [
     { name = "docling" },
     { name = "openai" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "qdrant-client" },
 ]
 
@@ -2018,6 +2019,7 @@ requires-dist = [
     { name = "docling", specifier = ">=2.36.1" },
     { name = "openai", specifier = ">=1.86.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
+    { name = "pydantic-settings", specifier = ">=2.3.0" },
     { name = "qdrant-client", specifier = ">=1.14.2" },
 ]
 


### PR DESCRIPTION
## Summary
- add session-scoped settings fixture for tests
- expose test fixtures via `pytest_plugins`
- update OpenAI embedding tests to consume shared settings

## Testing
- `ruff check tests/config/__init__.py tests/__init__.py tests/core/embedding_models/test_openai.py`
- `PYTHONPATH=src pytest -q` *(fails: ProxyError connecting to huggingface.co)*


------
https://chatgpt.com/codex/tasks/task_e_689320543ed08326b8f91f02ff4d2e9e