### PR TITLE
#28 Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "uv"
+    allow:
+      - dependency-type: "all"
+    groups:
+      patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+        labels:
+          - "patch"
+      major-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+        labels:
+          - "major"


### PR DESCRIPTION
## Summary
- add Dependabot setup for uv dependencies with weekly checks and labeled groups
- allow Dependabot to update all dependency types

## Testing
- `uv run ruff check .`
- `uv run pyright`
- `uv run pytest -m unit` *(fails: ProxyError to huggingface API)*

------
https://chatgpt.com/codex/tasks/task_e_689451e56fd4832681c1bcf66a764d0a